### PR TITLE
README suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use the current project version of Python
 poetry env use python3.11
 ```
 
-Download the Ediolon CLI
+Download the Eidolon CLI
 ```bash
 pip install 'eidolon-ai-client[cli]'
 ```

--- a/README.md
+++ b/README.md
@@ -18,13 +18,39 @@ make serve-dev
 ```
 
 ### Try it out
-First download the Ediolon CLI
+
+First, start a virtual environment
+
+MacOS:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Use the current project version of Python
+
+```bash
+poetry env use python3.11
+```
+
+Download the Ediolon CLI
 ```bash
 pip install 'eidolon-ai-client[cli]'
 ```
 
-The create an AgentProcess and run the converse action on it
+Create an AgentProcess and run the converse action on it 
+
+_Ensure the AgentMachine is already running from a terminal before doing this_
+
 ```bash
 export PID=$(eidolon-cli processes create --agent hello_world)
 eidolon-cli actions converse --process-id $PID --body "Hi! I made you"
 ```
+
+On your terminal, you should see the response from the agent.
+
+### Troubleshooting
+
+If commands like pip or python3 are not found, you may need to install them. See instructions in the
+[quickstart walkthrough](https://www.eidolonai.com/docs/prereq/)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ export PID=$(eidolon-cli processes create --agent hello_world)
 eidolon-cli actions converse --process-id $PID --body "Hi! I made you"
 ```
 
-On your terminal, you should see the response from the agent.
+In your terminal, you should see the response from the agent.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Here are some README suggestions that got me around some issues using the quickstart from a dev who isn't as experienced in Python

Issue: 

- I couldn't use the pip command because I wasn't in a venv (so it complained about global installs) and I wasn't in the right python env (so it complained when trying to run pip install)

Fix: 

Added instructions on starting a venv and configuring poetry to use the correct version